### PR TITLE
Updated Sleep, Added RSA check

### DIFF
--- a/.github/workflows/tls-testing.yml
+++ b/.github/workflows/tls-testing.yml
@@ -147,13 +147,12 @@ jobs:
         run: |
           docker exec client-container tcpdump -i any -w /shared/rsa_cipher_test.pcap &
           sleep 2
-          docker exec client-container curl -v --ciphers 'RSA' \
+          docker exec client-container curl -v --tlsv1.2 --ciphers 'AES256-SHA:AES128-SHA:DES-CBC3-SHA' \
             --cert /shared/client.crt \
             --key /shared/client.key \
             --cacert /shared/ca.crt -k https://server-container || true
           sleep 2
           docker exec client-container pidof tcpdump | xargs docker exec client-container kill
-          docker exec client-container killall tcpdump || true
           docker cp client-container:/shared/rsa_cipher_test.pcap artifacts/pcap/
 
       - name: Fix Permissions on Artifacts

--- a/.github/workflows/tls-testing.yml
+++ b/.github/workflows/tls-testing.yml
@@ -83,7 +83,6 @@ jobs:
           docker exec client-container curl -v https://server-container || true
           sleep 2
           docker exec client-container pidof tcpdump | xargs docker exec client-container kill
-          docker exec client-container killall tcpdump || true
           docker cp client-container:/shared/mtls_fail.pcap artifacts/pcap/
 
       - name: Test mTLS With Client Cert
@@ -94,7 +93,6 @@ jobs:
             --key /shared/client.key --cacert /shared/ca.crt -k https://server-container
           sleep 2
           docker exec client-container pidof tcpdump | xargs docker exec client-container kill
-          docker exec client-container killall tcpdump || true
           docker cp client-container:/shared/mtls_success.pcap artifacts/pcap/
 
       # Certificate Revocation (Step 8)
@@ -124,7 +122,6 @@ jobs:
             --key /shared/client.key --cacert /shared/ca.crt -k https://server-container || true
           sleep 2
           docker exec client-container pidof tcpdump | xargs docker exec client-container kill
-          docker exec client-container killall tcpdump || true
           docker cp client-container:/shared/mtls_revoked.pcap artifacts/pcap/
 
       - name: Issue New Client Certificate
@@ -144,7 +141,6 @@ jobs:
             --key /shared/client.key --cacert /shared/ca.crt -k https://server-container
           sleep 2
           docker exec client-container pidof tcpdump | xargs docker exec client-container kill
-          docker exec client-container killall tcpdump || true
           docker cp client-container:/shared/mtls_new_cert.pcap artifacts/pcap/
           
       - name: Test RSA Cipher Suite
@@ -158,7 +154,7 @@ jobs:
           sleep 2
           docker exec client-container pidof tcpdump | xargs docker exec client-container kill
           docker exec client-container killall tcpdump || true
-          docker cp client-container:/shared/rsa-ecc_cipher_test.pcap artifacts/pcap/
+          docker cp client-container:/shared/rsa_cipher_test.pcap artifacts/pcap/
 
       - name: Fix Permissions on Artifacts
         run: chmod -R 777 artifacts/pcap

--- a/.github/workflows/tls-testing.yml
+++ b/.github/workflows/tls-testing.yml
@@ -158,7 +158,7 @@ jobs:
             --cacert /shared/ca.crt -k https://server-container \
             --trace /shared/curl_debug_rsa-ecc.log || true
           sleep 10
-          docker exec client-container pidof tcpdump | xargs docker exec client-container kill
+          docker exec client-container pidof tcpdump | xargs docker exec client-container kill -2
           docker exec client-container pidof tcpdump || echo "tcpdump not running"
           docker cp client-container:/shared/curl_debug_rsa-ecc.log artifacts/logs/
           docker cp client-container:/shared/rsa-ecc_cipher_test.pcap artifacts/pcap/

--- a/.github/workflows/tls-testing.yml
+++ b/.github/workflows/tls-testing.yml
@@ -49,6 +49,7 @@ jobs:
           docker exec client-container pidof tcpdump | xargs docker exec client-container kill
           docker exec client-container pidof tcpdump || echo "tcpdump not running"
           docker exec client-container ls -l /shared/
+          sleep 2
           docker cp client-container:/shared/tls_handshake.pcap artifacts/pcap/
           ls -l artifacts/pcap
 
@@ -84,9 +85,10 @@ jobs:
           sleep 2
           docker exec client-container curl -v https://server-container \
           --trace /shared/curl_debug_mtls_fail.log || true
-          sleep 10
+          sleep 5
           docker exec client-container pidof tcpdump | xargs docker exec client-container kill
           docker exec client-container pidof tcpdump || echo "tcpdump not running"
+          sleep 2
           docker cp client-container:/shared/curl_debug_mtls_fail.log artifacts/logs/
           docker cp client-container:/shared/mtls_fail.pcap artifacts/pcap/
 
@@ -98,6 +100,7 @@ jobs:
             --key /shared/client.key --cacert /shared/ca.crt -k https://server-container
           sleep 5
           docker exec client-container pidof tcpdump | xargs docker exec client-container kill
+          sleep 2
           docker cp client-container:/shared/mtls_success.pcap artifacts/pcap/
 
       # Certificate Revocation (Step 8)
@@ -128,6 +131,7 @@ jobs:
             --cacert /shared/ca.crt -k https://server-container || true
           sleep 5
           docker exec client-container pidof tcpdump | xargs docker exec client-container kill
+          sleep 2
           docker cp client-container:/shared/mtls_revoked.pcap artifacts/pcap/
 
       - name: Issue New Client Certificate
@@ -147,6 +151,7 @@ jobs:
             --key /shared/client.key --cacert /shared/ca.crt -k https://server-container
           sleep 5
           docker exec client-container pidof tcpdump | xargs docker exec client-container kill
+          sleep 2
           docker cp client-container:/shared/mtls_new_cert.pcap artifacts/pcap/
           
       - name: Test RSA Cipher Suite
@@ -158,9 +163,10 @@ jobs:
             --key /shared/client.key \
             --cacert /shared/ca.crt -k https://server-container \
             --trace /shared/curl_debug_rsa-ecc.log || true
-          sleep 10
+          sleep 5
           docker exec client-container pidof tcpdump | xargs docker exec client-container kill
           docker exec client-container pidof tcpdump || echo "tcpdump not running"
+          sleep 2
           docker cp client-container:/shared/curl_debug_rsa-ecc.log artifacts/logs/
           docker cp client-container:/shared/rsa-ecc_cipher_test.pcap artifacts/pcap/
 

--- a/.github/workflows/tls-testing.yml
+++ b/.github/workflows/tls-testing.yml
@@ -145,7 +145,7 @@ jobs:
           
       - name: Test RSA Cipher Suite
         run: |
-          docker exec client-container tcpdump -i any -w /shared/rsa_cipher_test.pcap &
+          docker exec client-container tcpdump -i any -w /shared/rsa-ecc_cipher_test.pcap &
           sleep 2
           docker exec client-container curl -v --tlsv1.2 --tls-max 1.2 --ciphers 'AES256-SHA:AES128-SHA:DES-CBC3-SHA' \
             --cert /shared/client.crt \

--- a/.github/workflows/tls-testing.yml
+++ b/.github/workflows/tls-testing.yml
@@ -10,7 +10,9 @@ jobs:
       - name: Create Artifacts Directory
         run: |
           mkdir -p artifacts/pcap
+          mkdir -p artifacts/logs
           chmod -R 777 artifacts/pcap
+          chmod -R 777 artifacts/logs
       
       # Setup (Steps 1-3)
       - name: Install Docker Compose

--- a/.github/workflows/tls-testing.yml
+++ b/.github/workflows/tls-testing.yml
@@ -147,7 +147,7 @@ jobs:
         run: |
           docker exec client-container tcpdump -i any -w /shared/rsa_cipher_test.pcap &
           sleep 2
-          docker exec client-container curl -v --tlsv1.2 --ciphers 'AES256-SHA:AES128-SHA:DES-CBC3-SHA' \
+          docker exec client-container curl -v --tlsv1.2 --tls-max 1.2 --ciphers 'AES256-SHA:AES128-SHA:DES-CBC3-SHA' \
             --cert /shared/client.crt \
             --key /shared/client.key \
             --cacert /shared/ca.crt -k https://server-container || true

--- a/.github/workflows/tls-testing.yml
+++ b/.github/workflows/tls-testing.yml
@@ -150,9 +150,11 @@ jobs:
           docker exec client-container curl -v --tlsv1.2 --tls-max 1.2 --ciphers 'AES256-SHA:AES128-SHA:DES-CBC3-SHA' \
             --cert /shared/client.crt \
             --key /shared/client.key \
-            --cacert /shared/ca.crt -k https://server-container || true
+            --cacert /shared/ca.crt -k https://server-container
+            --trace /shared/curl_debug.log || true
           sleep 5
           docker exec client-container pidof tcpdump | xargs docker exec client-container kill
+          docker cp client-container:/shared/curl_debug.log artifacts/logs/
           docker cp client-container:/shared/rsa-ecc_cipher_test.pcap artifacts/pcap/
 
       - name: Fix Permissions on Artifacts

--- a/.github/workflows/tls-testing.yml
+++ b/.github/workflows/tls-testing.yml
@@ -43,7 +43,7 @@ jobs:
           docker exec client-container tcpdump -i any -w /shared/tls_handshake.pcap &
           sleep 2
           docker exec client-container curl -v -k https://server-container
-          sleep 2
+          sleep 5
           docker exec client-container pidof tcpdump | xargs docker exec client-container kill
           docker exec client-container pidof tcpdump || echo "tcpdump not running"
           docker exec client-container ls -l /shared/
@@ -81,7 +81,7 @@ jobs:
           docker exec client-container tcpdump -i any -w /shared/mtls_fail.pcap &
           sleep 2
           docker exec client-container curl -v https://server-container || true
-          sleep 2
+          sleep 5
           docker exec client-container pidof tcpdump | xargs docker exec client-container kill
           docker cp client-container:/shared/mtls_fail.pcap artifacts/pcap/
 
@@ -91,7 +91,7 @@ jobs:
           sleep 2
           docker exec client-container curl -v --cert /shared/client.crt \
             --key /shared/client.key --cacert /shared/ca.crt -k https://server-container
-          sleep 2
+          sleep 5
           docker exec client-container pidof tcpdump | xargs docker exec client-container kill
           docker cp client-container:/shared/mtls_success.pcap artifacts/pcap/
 
@@ -120,7 +120,7 @@ jobs:
           sleep 2
           docker exec client-container curl -v --cert /shared/client.crt \
             --key /shared/client.key --cacert /shared/ca.crt -k https://server-container || true
-          sleep 2
+          sleep 5
           docker exec client-container pidof tcpdump | xargs docker exec client-container kill
           docker cp client-container:/shared/mtls_revoked.pcap artifacts/pcap/
 
@@ -139,7 +139,7 @@ jobs:
           sleep 2
           docker exec client-container curl -v --cert /shared/client.crt \
             --key /shared/client.key --cacert /shared/ca.crt -k https://server-container
-          sleep 2
+          sleep 5
           docker exec client-container pidof tcpdump | xargs docker exec client-container kill
           docker cp client-container:/shared/mtls_new_cert.pcap artifacts/pcap/
           
@@ -151,7 +151,7 @@ jobs:
             --cert /shared/client.crt \
             --key /shared/client.key \
             --cacert /shared/ca.crt -k https://server-container || true
-          sleep 2
+          sleep 5
           docker exec client-container pidof tcpdump | xargs docker exec client-container kill
           docker cp client-container:/shared/rsa_cipher_test.pcap artifacts/pcap/
 

--- a/.github/workflows/tls-testing.yml
+++ b/.github/workflows/tls-testing.yml
@@ -82,9 +82,11 @@ jobs:
         run: |
           docker exec client-container tcpdump -i any -w /shared/mtls_fail.pcap &
           sleep 2
-          docker exec client-container curl -v https://server-container || true
+          docker exec client-container curl -v https://server-container \
+          --trace /shared/curl_debug_mtls_fail.log || true
           sleep 5
           docker exec client-container pidof tcpdump | xargs docker exec client-container kill
+          docker cp client-container:/shared/curl_debug_mtls_fail.log artifacts/logs/
           docker cp client-container:/shared/mtls_fail.pcap artifacts/pcap/
 
       - name: Test mTLS With Client Cert
@@ -121,7 +123,8 @@ jobs:
           docker exec client-container tcpdump -i any -w /shared/mtls_revoked.pcap &
           sleep 2
           docker exec client-container curl -v --cert /shared/client.crt \
-            --key /shared/client.key --cacert /shared/ca.crt -k https://server-container || true
+            --key /shared/client.key 
+            --cacert /shared/ca.crt -k https://server-container || true
           sleep 5
           docker exec client-container pidof tcpdump | xargs docker exec client-container kill
           docker cp client-container:/shared/mtls_revoked.pcap artifacts/pcap/
@@ -153,10 +156,10 @@ jobs:
             --cert /shared/client.crt \
             --key /shared/client.key \
             --cacert /shared/ca.crt -k https://server-container \
-            --trace /shared/curl_debug.log || true
+            --trace /shared/curl_debug_rsa-ecc.log || true
           sleep 5
           docker exec client-container pidof tcpdump | xargs docker exec client-container kill
-          docker cp client-container:/shared/curl_debug.log artifacts/logs/
+          docker cp client-container:/shared/curl_debug_rsa-ecc.log artifacts/logs/
           docker cp client-container:/shared/rsa-ecc_cipher_test.pcap artifacts/pcap/
 
       - name: Fix Permissions on Artifacts

--- a/.github/workflows/tls-testing.yml
+++ b/.github/workflows/tls-testing.yml
@@ -159,6 +159,7 @@ jobs:
             --trace /shared/curl_debug_rsa-ecc.log || true
           sleep 10
           docker exec client-container pidof tcpdump | xargs docker exec client-container kill
+          docker exec client-container pidof tcpdump || echo "tcpdump not running"
           docker cp client-container:/shared/curl_debug_rsa-ecc.log artifacts/logs/
           docker cp client-container:/shared/rsa-ecc_cipher_test.pcap artifacts/pcap/
 

--- a/.github/workflows/tls-testing.yml
+++ b/.github/workflows/tls-testing.yml
@@ -123,7 +123,7 @@ jobs:
           docker exec client-container tcpdump -i any -w /shared/mtls_revoked.pcap &
           sleep 2
           docker exec client-container curl -v --cert /shared/client.crt \
-            --key /shared/client.key 
+            --key /shared/client.key \
             --cacert /shared/ca.crt -k https://server-container || true
           sleep 5
           docker exec client-container pidof tcpdump | xargs docker exec client-container kill
@@ -151,13 +151,13 @@ jobs:
       - name: Test RSA Cipher Suite
         run: |
           docker exec client-container tcpdump -i any -w /shared/rsa-ecc_cipher_test.pcap &
-          sleep 2
+          sleep 5
           docker exec client-container curl -v --tlsv1.2 --tls-max 1.2 --ciphers 'AES256-SHA:AES128-SHA:DES-CBC3-SHA' \
             --cert /shared/client.crt \
             --key /shared/client.key \
             --cacert /shared/ca.crt -k https://server-container \
             --trace /shared/curl_debug_rsa-ecc.log || true
-          sleep 5
+          sleep 10
           docker exec client-container pidof tcpdump | xargs docker exec client-container kill
           docker cp client-container:/shared/curl_debug_rsa-ecc.log artifacts/logs/
           docker cp client-container:/shared/rsa-ecc_cipher_test.pcap artifacts/pcap/

--- a/.github/workflows/tls-testing.yml
+++ b/.github/workflows/tls-testing.yml
@@ -84,8 +84,9 @@ jobs:
           sleep 2
           docker exec client-container curl -v https://server-container \
           --trace /shared/curl_debug_mtls_fail.log || true
-          sleep 5
+          sleep 10
           docker exec client-container pidof tcpdump | xargs docker exec client-container kill
+          docker exec client-container pidof tcpdump || echo "tcpdump not running"
           docker cp client-container:/shared/curl_debug_mtls_fail.log artifacts/logs/
           docker cp client-container:/shared/mtls_fail.pcap artifacts/pcap/
 
@@ -158,7 +159,7 @@ jobs:
             --cacert /shared/ca.crt -k https://server-container \
             --trace /shared/curl_debug_rsa-ecc.log || true
           sleep 10
-          docker exec client-container pidof tcpdump | xargs docker exec client-container kill -2
+          docker exec client-container pidof tcpdump | xargs docker exec client-container kill
           docker exec client-container pidof tcpdump || echo "tcpdump not running"
           docker cp client-container:/shared/curl_debug_rsa-ecc.log artifacts/logs/
           docker cp client-container:/shared/rsa-ecc_cipher_test.pcap artifacts/pcap/

--- a/.github/workflows/tls-testing.yml
+++ b/.github/workflows/tls-testing.yml
@@ -146,6 +146,19 @@ jobs:
           docker exec client-container pidof tcpdump | xargs docker exec client-container kill
           docker exec client-container killall tcpdump || true
           docker cp client-container:/shared/mtls_new_cert.pcap artifacts/pcap/
+          
+      - name: Test RSA Cipher Suite
+        run: |
+          docker exec client-container tcpdump -i any -w /shared/rsa_cipher_test.pcap &
+          sleep 2
+          docker exec client-container curl -v --ciphers 'RSA' \
+            --cert /shared/client.crt \
+            --key /shared/client.key \
+            --cacert /shared/ca.crt -k https://server-container || true
+          sleep 2
+          docker exec client-container pidof tcpdump | xargs docker exec client-container kill
+          docker exec client-container killall tcpdump || true
+          docker cp client-container:/shared/rsa-ecc_cipher_test.pcap artifacts/pcap/
 
       - name: Fix Permissions on Artifacts
         run: chmod -R 777 artifacts/pcap

--- a/.github/workflows/tls-testing.yml
+++ b/.github/workflows/tls-testing.yml
@@ -150,7 +150,7 @@ jobs:
           docker exec client-container curl -v --tlsv1.2 --tls-max 1.2 --ciphers 'AES256-SHA:AES128-SHA:DES-CBC3-SHA' \
             --cert /shared/client.crt \
             --key /shared/client.key \
-            --cacert /shared/ca.crt -k https://server-container
+            --cacert /shared/ca.crt -k https://server-container \
             --trace /shared/curl_debug.log || true
           sleep 5
           docker exec client-container pidof tcpdump | xargs docker exec client-container kill

--- a/.github/workflows/tls-testing.yml
+++ b/.github/workflows/tls-testing.yml
@@ -160,13 +160,21 @@ jobs:
           docker cp client-container:/shared/rsa-ecc_cipher_test.pcap artifacts/pcap/
 
       - name: Fix Permissions on Artifacts
-        run: chmod -R 777 artifacts/pcap
+        run: |
+          chmod -R 777 artifacts/pcap
+          chmod -R 777 artifacts/logs
 
       - name: Upload TLS Handshake Artifact
         uses: actions/upload-artifact@v3
         with:
           name: tls-testing-pcaps
           path: artifacts/pcap/
+          
+      - name: Upload Curl Logs
+        uses: actions/upload-artifact@v3
+        with:
+          name: curl-logs
+          path: artifacts/logs/
           
       - name: Cleanup
         if: always()

--- a/.github/workflows/tls-testing.yml
+++ b/.github/workflows/tls-testing.yml
@@ -153,7 +153,7 @@ jobs:
             --cacert /shared/ca.crt -k https://server-container || true
           sleep 5
           docker exec client-container pidof tcpdump | xargs docker exec client-container kill
-          docker cp client-container:/shared/rsa_cipher_test.pcap artifacts/pcap/
+          docker cp client-container:/shared/rsa-ecc_cipher_test.pcap artifacts/pcap/
 
       - name: Fix Permissions on Artifacts
         run: chmod -R 777 artifacts/pcap


### PR DESCRIPTION
Hi,

I noticed mtls_fail.pcap was empty despite the run output showing packets captured. I added a sleep command after the tcpdump kill line to remedy.

Also, I saw for Discussion item 4 we can produce some evidence using our existing setup, so I added an additional "Test RSA Cipher Suite" section. Also added a artifacts/logs section to have curl logs for the mTLS fail as well as the RSA to ECC (1.2 to 1.3) test in case we want to include in any writeup.

Cheers,

Scott